### PR TITLE
dont load winamp radio player on mobile device

### DIFF
--- a/_imports/scripts.html
+++ b/_imports/scripts.html
@@ -9,12 +9,4 @@
 <script src="js/main.js"></script>
 <script src="js/chatbot.js"></script>
 <script src="https://unpkg.com/webamp@1.4.2/built/webamp.bundle.min.js"></script>
-<script>
-  const webAmp = window.Webamp;
-  new webAmp({
-    zIndex: 999,
-    initialTracks: [
-      { url: "https://radio.neet.space/stream.mp3", duration: 0.0 },
-    ],
-  }).renderWhenReady(document.getElementById("radio"));
-</script>
+<script src="js/winamp.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -48,6 +48,13 @@
   right: 0;
 }
 
+/* dont display radio on Smartphones ----------- */
+@media only screen and (max-width: 600px) {
+  #radio {
+    display: none;
+  }
+}
+
 .readable-white {
   background: -o-linear-gradient(
     left,

--- a/css/style.css
+++ b/css/style.css
@@ -50,7 +50,7 @@
 
 /* dont display radio on Smartphones ----------- */
 @media only screen and (max-width: 600px) {
-  #radio {
+  .not_on_mobile {
     display: none;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -48,7 +48,7 @@
   right: 0;
 }
 
-/* dont display radio on Smartphones ----------- */
+/* dont display on Smartphones ----------- */
 @media only screen and (max-width: 600px) {
   .not_on_mobile {
     display: none;

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
     <circle class="path" cx="24" cy="24" r="22" fill="none" stroke-width="4" stroke-miterlimit="10" stroke="#f4b214" />
   </svg></div>
 
-<div id="radio" style="z-index: 1;"></div>
+<div class="not_on_mobile" id="radio" style="z-index: 1;"></div>
 
 <sergey-import src="scripts" />
 </body>

--- a/js/winamp.js
+++ b/js/winamp.js
@@ -1,7 +1,7 @@
 // display radio only if screen is wide enough (i.e. not on mobile device)
-const doDisplayRadioPlayer = $("#radio").css("display") != "none";
+const doLoadRadioPlayer = $(".not_on_mobile").css("display") != "none";
 
-if (doDisplayRadioPlayer) {
+if (doLoadRadioPlayer) {
   const webAmp = window.Webamp;
   new webAmp({
     zIndex: 999,

--- a/js/winamp.js
+++ b/js/winamp.js
@@ -1,0 +1,12 @@
+// display radio only if screen is wide enough (i.e. not on mobile device)
+const doDisplayRadioPlayer = $("#radio").css("display") != "none";
+
+if (doDisplayRadioPlayer) {
+  const webAmp = window.Webamp;
+  new webAmp({
+    zIndex: 999,
+    initialTracks: [
+      { url: "https://radio.neet.space/stream.mp3", duration: 0.0 },
+    ],
+  }).renderWhenReady(document.getElementById("radio"));
+}


### PR DESCRIPTION
winamp radio player should not be loaded on narrow screens (less than 600pixels wide)

my fix leverage css to detect screen width

hiding radio div is not enough, we must also prevent javascript from loading the radio app.  

based on the css display field, javascript decide if it should load radio player or not

@luxemboye  please merge to main if satisfied by my fix