### PR TITLE
maxstertrooper: remove blur and mismatched stretching

### DIFF
--- a/maxstertrooper/js/commonTools.js
+++ b/maxstertrooper/js/commonTools.js
@@ -42,7 +42,7 @@ function clearScreen(canvas) {
   context.clearRect(0, 0, canvas.width, canvas.height);
 }
 
-function scaleScreen(canvas, width, height, smooth=true) {
+function scaleScreen(canvas, context, width, height, smooth=true) {
   var scale = window.devicePixelRatio || 1;
   var container = canvas.parentNode.getBoundingClientRect();
   var zoom = Math.min(

--- a/maxstertrooper/js/commonTools.js
+++ b/maxstertrooper/js/commonTools.js
@@ -41,3 +41,20 @@ function clearScreen(canvas) {
   var context = canvas.getContext("2d");
   context.clearRect(0, 0, canvas.width, canvas.height);
 }
+
+function scaleScreen(canvas, width, height, smooth=true) {
+  var scale = window.devicePixelRatio || 1;
+  var container = canvas.parentNode.getBoundingClientRect();
+  var zoom = Math.min(
+    (container.height / height),
+    (container.width / width),
+  );
+  var zoomScale = zoom * scale;
+  canvas.style.height = `${height * zoom}px`;
+  canvas.style.width = `${width * zoom}px`;
+  if(smooth){
+    canvas.height = height * zoomScale;
+    canvas.width = width * zoomScale;
+    context.scale(zoomScale, zoomScale);
+  }
+}

--- a/maxstertrooper/js/logic.js
+++ b/maxstertrooper/js/logic.js
@@ -1,12 +1,14 @@
 const WINNING_TRESHOLD = 75;
 
 class Runner {
-  constructor(canvas, context) {
+  constructor(canvas, context, width, height) {
     this.canvas = canvas;
     this.context = context;
+    this.height = height;
+    this.width = width;
     this.flyers = {};
     this.bullets = {};
-    this.cannon = new Cannon(canvas.width, canvas.height);
+    this.cannon = new Cannon(this.width, this.height);
     this.display = new PointsDisplay();
     this.points = 15;
     this.loopingInverval = null;
@@ -194,7 +196,7 @@ class Runner {
         }
       }
     } else {
-      if (flyer.x < self.canvas.width) {
+      if (flyer.x < self.width) {
         flyer.moveRight();
       } else {
         flyer.moveLeft();

--- a/maxstertrooper/js/main.js
+++ b/maxstertrooper/js/main.js
@@ -5,7 +5,7 @@ var gameRunner = new Runner(canvas, context, /*width=*/ 300, /*height=*/ 150);
 
 // scale canvas
 //
-scaleScreen(canvas, gameRunner.width, gameRunner.height, /*smooth=*/ true);
+scaleScreen(canvas, context, gameRunner.width, gameRunner.height, /*smooth=*/ true);
 
 // display main menu
 //

--- a/maxstertrooper/js/main.js
+++ b/maxstertrooper/js/main.js
@@ -1,7 +1,11 @@
 var canvas = document.getElementById("mainCanvas");
 var context = canvas.getContext("2d");
 
-var gameRunner = new Runner(canvas, context);
+var gameRunner = new Runner(canvas, context, /*width=*/ 300, /*height=*/ 150);
+
+// scale canvas
+//
+scaleScreen(canvas, gameRunner.width, gameRunner.height, /*smooth=*/ true);
 
 // display main menu
 //
@@ -14,11 +18,11 @@ function checkKey(e) {
 
   switch (event.code) {
     case "ArrowRight":
-      gameRunner.moveCannonRight(gameRunner, canvas.width);
+      gameRunner.moveCannonRight(gameRunner, gameRunner.width);
       break;
 
     case "ArrowLeft":
-      gameRunner.moveCannonLeft(gameRunner, canvas.width);
+      gameRunner.moveCannonLeft(gameRunner, gameRunner.width);
       break;
 
     case "ArrowUp":

--- a/maxstertrooper/js/visualArtefact.js
+++ b/maxstertrooper/js/visualArtefact.js
@@ -58,7 +58,7 @@ class PointsDisplay extends VisualArtefact {
   gameOver(context) {
     textToCanvas(
       context,
-      "Game over : refresh browser (F5) to play again !",
+      "Game over : press R to play again !",
       this.x,
       this.y,
       this.innercolor,

--- a/maxstertrooper/styles/customStyles.css
+++ b/maxstertrooper/styles/customStyles.css
@@ -12,19 +12,22 @@
 }
 
 .customMain {
+  background-color: #91967f;
   position: absolute;
   left: 0;
   width: 100%;
   top: 100px;
   overflow: auto;
+
+  /*   100vh == screen total height ; 160px == header.height + footer.height */
+  height: calc(100vh - 160px);
 }
 
 .customCanvas {
   background-color: black;
-  width: 100%;
-
-  /*   100vh == screen total height ; 160px == header.height + footer.height */
-  height: calc(100vh - 160px);
+  display: block;
+  image-rendering: pixelated;
+  margin: auto;
 }
 
 .customFooter {


### PR DESCRIPTION
Since you did not specify a canvas resolution, you probably designed the game for the default 300*150 canvas size. Luckily, this is about the resolution of the game you were referencing.

To resize an HTML element while maintaining an aspect ratio, find the minimum between the ideal horizontal and vertical scaling factors. (If integer scaling were desired, this number could be rounded down.)

Additionally, the canvas context scale() method increases the resolution of the game for larger displays. We can also double the resolution for HiDPI displays.

However, the scaling almost works too well. I've made the smooth scaling optional. When this is disabled, it leaves us with a crisp pixel art style that may be preferred.